### PR TITLE
Labels automaticas

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,0 +1,12 @@
+name: Labeling new issue
+on:
+  issues:
+      types: ['opened']
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Renato66/auto-label@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          labels-not-allowed: '["Expirada"]'


### PR DESCRIPTION
Dei uma estudada no github actions e desenvolvi esta action [auto-label](https://github.com/marketplace/actions/auto-label)

basicamente ele lê o corpo de uma issue e baseado em uma comparação de strings ele irá colocar a label na issue automaticamente
