### PR TITLE
Fecha issues antigas em 7 dias

### DIFF
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Esta vaga encontra-se há um bom tempo sem novas interações. Se ainda estiver aberta, faça um comentário, caso contrario, a fecharemos automaticamente em 5 dias.'
+        stale-issue-message: 'Esta vaga encontra-se há um bom tempo sem novas interações. Se ainda estiver aberta, faça um comentário, caso contrario, a fecharemos automaticamente em 7 dias.'
         days-before-stale: 60
-        days-before-close: 30
+        days-before-close: 7
         ascending: true


### PR DESCRIPTION
A maior parte das issues que receberam o comentário automático não teve resposta. Por isso, a sugestão é reduzir o período para que menos issues antigas continuem pendentes.